### PR TITLE
_hat_info: close eeprom file fd before returning

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -1056,6 +1056,8 @@ int _hat_info(uint8_t address, struct HatInfo* entry, char* pData,
         else
         {
             // no board info found
+            if (eeprom_fd != 1)
+                close(eeprom_fd);
             return RESULT_BAD_PARAMETER;
         }
 
@@ -1077,7 +1079,10 @@ int _hat_info(uint8_t address, struct HatInfo* entry, char* pData,
         {
             *pSize = custom_size + 1;   // add room for null
         }
+        if (eeprom_fd != -1)
+            close(eeprom_fd);
     }
+    
 
     return RESULT_SUCCESS;
 }

--- a/tools/daqhats_read_eeproms
+++ b/tools/daqhats_read_eeproms
@@ -62,7 +62,11 @@ if [ "$rc" != 0 ]; then
    exit $rc
 fi
 
+# /sys/class/i2c-adapter is deprecated since 2009
 SYS=/sys/class/i2c-adapter/i2c-$BUS
+if [ ! -d "$SYS" ]; then
+	SYS=/sys/bus/i2c/devices/i2c-$BUS
+fi
 
 rm -f /etc/mcc/hats/*.bin
 


### PR DESCRIPTION
The file descriptor was left open after the function returns.